### PR TITLE
Include gst-python

### DIFF
--- a/Dockerfile-dev-downloaded
+++ b/Dockerfile-dev-downloaded
@@ -29,6 +29,9 @@ ARG GST_LIBAV_CHECKOUT=e0be2033a03547135ffda9faa596ffdba939a61e
 ARG GSTREAMER_VAAPI_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi.git
 ARG GSTREAMER_VAAPI_CHECKOUT=26143333899382035e66f0360019c67d4a252e78
 
+ARG GST_PYTHON_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-python.git
+ARG GST_PYTHON_CHECKOUT=f9eac69d5409982e23ac5cd401f65fc5a07e92cb
+
 COPY docker/build-gstreamer/download /
 
 RUN ["/download"]

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-for repo in gstreamer libnice gst-plugins-base libwpe wpebackend-fdo wpewebkit gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav gstreamer-vaapi; do
+for repo in gstreamer libnice gst-plugins-base libwpe wpebackend-fdo wpewebkit gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav gstreamer-vaapi gst-python; do
   pushd $repo
   # wpewebkit is cmake...
   if [[ $repo == 'wpewebkit' ]]; then

--- a/docker/build-gstreamer/download
+++ b/docker/build-gstreamer/download
@@ -56,3 +56,7 @@ pushd gstreamer-vaapi
 git checkout "$GSTREAMER_VAAPI_CHECKOUT"
 popd
 
+git clone --no-checkout "$GST_PYTHON_REPOSITORY"
+pushd gst-python
+git checkout "$GST_PYTHON_CHECKOUT"
+popd

--- a/docker/build-gstreamer/install-dependencies
+++ b/docker/build-gstreamer/install-dependencies
@@ -121,7 +121,8 @@ apt-get install -y --no-install-recommends \
   intel-media-va-driver-non-free \
   libudev-dev \
   python3-gi \
-  python3-gst-1.0
+  python3-gst-1.0 \
+  python-gi-dev
 pip3 install meson ninja --no-cache-dir
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/docker/build-gstreamer/install-dependencies
+++ b/docker/build-gstreamer/install-dependencies
@@ -119,7 +119,9 @@ apt-get install -y --no-install-recommends \
   libva-dev \
   libmfx-dev \
   intel-media-va-driver-non-free \
-  libudev-dev
-pip3 install meson ninja
+  libudev-dev \
+  python3-gi \
+  python3-gst-1.0
+pip3 install meson ninja --no-cache-dir
 apt-get clean
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hello!

I propose a modification to include `gst-python` when building images. This requires a few additional dependencies and a small change in compiling process. Hope for merging this to upstream.

BTW: please add Issues tab - in README there is an encouragement to submit issues, but currently it's not possible.