### PR TITLE
latest: Port to GStreamer mono-repo

### DIFF
--- a/Dockerfile-dev-downloaded
+++ b/Dockerfile-dev-downloaded
@@ -2,7 +2,7 @@ FROM restreamio/gstreamer:dev-dependencies
 
 ARG GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/philn/gstreamer.git
 # 1.20-studio branch
-ARG GSTREAMER_CHECKOUT=3ee7fe24bafb6df1e2c2d9182e1b39a04b9d3279
+ARG GSTREAMER_CHECKOUT=622f7f11755a525f2e15c1841367f4b7f73e9def
 
 ARG LIBWPE_VERSION=1.12.0
 ARG WPEBACKEND_FDO_VERSION=1.12.0

--- a/Dockerfile-dev-downloaded
+++ b/Dockerfile-dev-downloaded
@@ -1,35 +1,15 @@
 FROM restreamio/gstreamer:dev-dependencies
 
-ARG GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/nazar-pc/gstreamer.git
-ARG GSTREAMER_CHECKOUT=e78ecbbeec58e973328ff66e12cf06d1e92d2e9c
+ARG GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/philn/gstreamer.git
+# 1.20-studio branch
+ARG GSTREAMER_CHECKOUT=3ee7fe24bafb6df1e2c2d9182e1b39a04b9d3279
 
 ARG LIBWPE_VERSION=1.12.0
 ARG WPEBACKEND_FDO_VERSION=1.12.0
-ARG WPEWEBKIT_VERSION=2.34.1
+ARG WPEWEBKIT_VERSION=2.34.6
 
-ARG LIBNICE_REPOSITORY=https://gitlab.freedesktop.org/libnice/libnice.git
-ARG LIBNICE_CHECKOUT=a0cfef727f6fdbc584514b6eefc6d9743874df97
-
-ARG GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/nazar-pc/gst-plugins-base.git
-ARG GST_PLUGINS_BASE_CHECKOUT=ff1483c5201ef74a0a3bf7f9aba017f28b183582
-
-ARG GST_PLUGINS_BAD_REPOSITORY=https://gitlab.freedesktop.org/philn/gst-plugins-bad.git
-ARG GST_PLUGINS_BAD_CHECKOUT=02546967c2ed6f3610cb507d755b0073fb9c502b
-
-ARG GST_PLUGINS_GOOD_REPOSITORY=https://gitlab.freedesktop.org/nazar-pc/gst-plugins-good.git
-ARG GST_PLUGINS_GOOD_CHECKOUT=ea3f562cd783631ba0bea98e873aadf61ce69f10
-
-ARG GST_PLUGINS_UGLY_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git
-ARG GST_PLUGINS_UGLY_CHECKOUT=cc1a7e2c4d10ab118d635a9db163440bc9d96dd0
-
-ARG GST_LIBAV_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-libav.git
-ARG GST_LIBAV_CHECKOUT=17aca8a8c2b581b11b539a6a138241302cce7290
-
-ARG GSTREAMER_VAAPI_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi.git
-ARG GSTREAMER_VAAPI_CHECKOUT=677d1e01051e2ee47439cff7cc7f527bb71afbb8
-
-COPY docker/build-gstreamer/download /
+COPY docker/build-gstreamer/download /download
 
 RUN ["/download"]
 
-COPY docker/build-gstreamer/compile /
+COPY docker/build-gstreamer/compile /compile

--- a/Dockerfile-prod-base
+++ b/Dockerfile-prod-base
@@ -1,5 +1,7 @@
 FROM ubuntu:21.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN \
     apt-get update && \
     apt-get dist-upgrade -y && \
@@ -18,6 +20,7 @@ RUN \
         libgles2 \
         libgudev-1.0-0 \
         libgbm1 \
+        libgraphene-1.0-dev \
         libpng16-16 \
         libjpeg8 \
         libogg0 \

--- a/Dockerfile-prod-base
+++ b/Dockerfile-prod-base
@@ -114,6 +114,7 @@ RUN \
         libavutil56 \
         libva2 \
         libmfx1 \
+        libva-wayland2 \
         intel-media-va-driver-non-free && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/build-release.sh
+++ b/build-release.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [[ -z "$1" ]]; then
-    echo -e "Usage example:\n  $0 1.18.1"
+    echo -e "Usage example:\n  $0 1.20.1"
     exit 1
 fi
 
@@ -14,18 +14,6 @@ docker build -t restreamio/gstreamer:dev-dependencies -f Dockerfile-dev-dependen
 docker build -t restreamio/gstreamer:dev-downloaded \
     --build-arg GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
     --build-arg GSTREAMER_CHECKOUT=$1 \
-    --build-arg GST_PLUGINS_BASE_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git \
-    --build-arg GST_PLUGINS_BASE_CHECKOUT=$1 \
-    --build-arg GST_PLUGINS_BAD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git \
-    --build-arg GST_PLUGINS_BAD_CHECKOUT=$1 \
-    --build-arg GST_PLUGINS_GOOD_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git \
-    --build-arg GST_PLUGINS_GOOD_CHECKOUT=$1 \
-    --build-arg GST_PLUGINS_UGLY_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git \
-    --build-arg GST_PLUGINS_UGLY_CHECKOUT=$1 \
-    --build-arg GST_LIBAV_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gst-libav.git \
-    --build-arg GST_LIBAV_CHECKOUT=$1 \
-    --build-arg GSTREAMER_VAAPI_REPOSITORY=https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi.git \
-    --build-arg GSTREAMER_VAAPI_CHECKOUT=$1 \
     -f Dockerfile-dev-downloaded .
 # Build dev image with source code included
 docker build -t restreamio/gstreamer:$1-dev-with-source -f Dockerfile-dev-with-source .

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -1,93 +1,88 @@
 #!/bin/bash
 set -e
 
-for repo in gstreamer libnice gst-plugins-base libwpe wpebackend-fdo wpewebkit gst-plugins-bad gst-plugins-good gst-plugins-ugly gst-libav gstreamer-vaapi; do
+# Compile GStreamer dependencies first.
+for repo in libwpe wpebackend-fdo; do
   pushd $repo
-  NINJA_OPTS=""
-  # wpewebkit is cmake...
-  if [[ $repo == 'wpewebkit' ]]; then
-    mkdir build
-    pushd build
-    # TODO: Remove `-DUSE_GSTREAMER_GL=OFF` once configurable in runtime
-    if [[ $DEBUG == 'true' ]]; then
-      if [[ $OPTIMIZATIONS == 'true' ]]; then
-        # RelWithDebInfo is huge, hence just release, we're unlikely to actually debug it
-        cmake \
-          -DCMAKE_INSTALL_PREFIX=/usr \
-          -DPORT=WPE \
-          -DUSE_SYSTEMD=OFF \
-          -DENABLE_ACCESSIBILITY=OFF \
-          -DENABLE_WEBDRIVER=OFF \
-          -DUSE_GSTREAMER_GL=OFF \
-          -DUSE_SOUP2=ON \
-          -DCMAKE_BUILD_TYPE=Release \
-          -GNinja ..
-      else
-        cmake \
-          -DCMAKE_INSTALL_PREFIX=/usr \
-          -DPORT=WPE \
-          -DUSE_SYSTEMD=OFF \
-          -DENABLE_ACCESSIBILITY=OFF \
-          -DENABLE_WEBDRIVER=OFF \
-          -DUSE_GSTREAMER_GL=OFF \
-          -DUSE_SOUP2=ON \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -GNinja ..
-      fi
+  if [[ $DEBUG == 'true' ]]; then
+    if [[ $OPTIMIZATIONS == 'true' ]]; then
+      meson build -D prefix=/usr -D buildtype=debugoptimized
     else
-      cmake \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DPORT=WPE \
-        -DUSE_SYSTEMD=OFF \
-        -DENABLE_ACCESSIBILITY=OFF \
-        -DENABLE_WEBDRIVER=OFF \
-        -DUSE_GSTREAMER_GL=OFF \
-        -DUSE_SOUP2=ON \
-        -DCMAKE_BUILD_TYPE=Release \
-        -GNinja ..
+      meson build -D prefix=/usr -D buildtype=debug
     fi
-    popd
-
-    # Relax CPU load, unified builds require a lot of RAM and can easily overload
-    # the machine when using all cores.
-    NCPU=$(nproc)
-    NINJA_OPTS="-j $(($NCPU/2))"
-
   else
-    # TODO: Hack: `-D gupnp=disabled` is for libnice, because libgupnp-igd causes memory leaks
-    # msdk=enabled is for gst-plugings-bad to include msdk elements
-    # with_x11=no is for gstreamer-vaapi to exclude X11-related functionality (that would otherwise require extra dependencies)
-    MESON_OPTS=""
-    if [[ $repo == 'libnice' ]]; then
-      MESON_OPTS="-Dgupnp=disabled"
-    fi
-    if [[ $repo == 'gst-plugins-bad' ]]; then
-      MESON_OPTS="-Dmsdk=enabled"
-    fi
-    if [[ $repo == 'gstreamer-vaapi' ]]; then
-      MESON_OPTS="-Dwith_x11=no"
-    fi
-    if [[ $DEBUG == 'true' ]]; then
-      if [[ $OPTIMIZATIONS == 'true' ]]; then
-        meson build -D prefix=/usr $MESON_OPTS -D debug=true -D optimization=2
-      else
-        meson build -D prefix=/usr $MESON_OPTS -D debug=true
-      fi
-    else
-        meson build -D prefix=/usr $MESON_OPTS -D debug=false -D optimization=3 -D b_lto=true
-    fi
+    meson build -D prefix=/usr -D buildtype=release -D b_lto=true
   fi
+
   # This is needed for other plugins to be built properly
-  ninja $NINJA_OPTS -C build install
+  ninja -C build install
   # This is where we'll grab build artifacts from
-  DESTDIR=/compiled-binaries ninja $NINJA_OPTS -C build install
-
-  if [[ $repo == 'wpewebkit' ]]; then
-    # It is too large for us to afford storing it unfortunately, ~16GiB as of writing this message
-    rm -rf build
-  fi
-
+  DESTDIR=/compiled-binaries ninja -C build install
   popd
 done
+
+pushd gstreamer
+# TODO: Hack: `-D gupnp=disabled` is for libnice, because libgupnp-igd causes memory leaks
+# msdk=enabled is for gst-plugings-bad to include msdk elements
+# with_x11=no is for gstreamer-vaapi to exclude X11-related functionality (that would otherwise require extra dependencies)
+MESON_OPTIONS="-Dvaapi=enabled -Dgpl=enabled -Dexamples=disabled -Dtests=disabled -Ddoc=disabled -Dqt5=disabled -Dpython=disabled -Dges=disabled -Ddevtools=disabled -Dintrospection=disabled -Dlibnice:gupnp=disabled -Dgst-plugins-bad:msdk=enabled -Dgstreamer-vaapi:with_x11=no"
+if [[ $DEBUG == 'true' ]]; then
+  if [[ $OPTIMIZATIONS == 'true' ]]; then
+    meson build -D prefix=/usr $MESON_OPTIONS -D buildtype=debugoptimized
+  else
+    meson build -D prefix=/usr $MESON_OPTIONS -D buildtype=debug
+  fi
+else
+  meson build -D prefix=/usr $MESON_OPTIONS -D buildtype=release -D b_lto=true
+fi
+# This is needed for other plugins to be built properly
+ninja -C build install
+# This is where we'll grab build artifacts from
+DESTDIR=/compiled-binaries ninja -C build install
+popd
+
+# Compile WPEWebKit
+pushd wpewebkit
+mkdir build
+pushd build
+WPE_CMAKE_OPTS="-DCMAKE_INSTALL_PREFIX=/usr \
+  -DPORT=WPE \
+  -DENABLE_ACCESSIBILITY=OFF \
+  -DENABLE_WEBDRIVER=OFF \
+  -DUSE_SOUP2=ON \
+  -DUSE_SYSTEMD=OFF -GNinja"
+if [[ $DEBUG == 'true' ]]; then
+  if [[ $OPTIMIZATIONS == 'true' ]]; then
+    # RelWithDebInfo is huge, hence just release, we're unlikely to actually debug it
+    cmake -DCMAKE_BUILD_TYPE=Release $WPE_CMAKE_OPTS ..
+  else
+    cmake -DCMAKE_BUILD_TYPE=Debug $WPE_CMAKE_OPTS ..
+  fi
+else
+  cmake -DCMAKE_BUILD_TYPE=Release $WPE_CMAKE_OPTS ..
+fi
+popd
+
+# Relax CPU load, unified builds require a lot of RAM and can easily overload
+# the machine when using all cores.
+NCPU=$(nproc)
+NINJA_OPTS="-j $(($NCPU/2))"
+
+ninja $NINJA_OPTS -C build
+ninja $NINJA_OPTS -C build install
+# This is where we'll grab build artifacts from
+DESTDIR=/compiled-binaries ninja -C build install
+
+# It is too large for us to afford storing it unfortunately, ~16GiB as of writing this message
+rm -rf build
+popd
+
+# Re-build GStreamer with WPE enabled
+pushd gstreamer
+meson build --reconfigure -Dgst-plugins-bad:wpe=enabled
+ninja -C build install
+# This is where we'll grab build artifacts from
+DESTDIR=/compiled-binaries ninja -C build install
+popd
 
 gst-inspect-1.0

--- a/docker/build-gstreamer/download
+++ b/docker/build-gstreamer/download
@@ -6,16 +6,6 @@ pushd gstreamer
 git checkout "$GSTREAMER_CHECKOUT"
 popd
 
-git clone --no-checkout "$LIBNICE_REPOSITORY"
-pushd libnice
-git checkout "$LIBNICE_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_PLUGINS_BASE_REPOSITORY"
-pushd gst-plugins-base
-git checkout "$GST_PLUGINS_BASE_CHECKOUT"
-popd
-
 wget https://wpewebkit.org/releases/libwpe-$LIBWPE_VERSION.tar.xz
 tar -xf libwpe-$LIBWPE_VERSION.tar.xz
 rm libwpe-$LIBWPE_VERSION.tar.xz
@@ -30,29 +20,3 @@ wget https://wpewebkit.org/releases/wpewebkit-$WPEWEBKIT_VERSION.tar.xz
 tar -xf wpewebkit-$WPEWEBKIT_VERSION.tar.xz
 rm wpewebkit-$WPEWEBKIT_VERSION.tar.xz
 mv wpewebkit-$WPEWEBKIT_VERSION wpewebkit
-
-git clone --no-checkout "$GST_PLUGINS_BAD_REPOSITORY"
-pushd gst-plugins-bad
-git checkout "$GST_PLUGINS_BAD_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_PLUGINS_GOOD_REPOSITORY"
-pushd gst-plugins-good
-git checkout "$GST_PLUGINS_GOOD_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_PLUGINS_UGLY_REPOSITORY"
-pushd gst-plugins-ugly
-git checkout "$GST_PLUGINS_UGLY_CHECKOUT"
-popd
-
-git clone --no-checkout "$GST_LIBAV_REPOSITORY"
-pushd gst-libav
-git checkout "$GST_LIBAV_CHECKOUT"
-popd
-
-git clone --no-checkout "$GSTREAMER_VAAPI_REPOSITORY"
-pushd gstreamer-vaapi
-git checkout "$GSTREAMER_VAAPI_CHECKOUT"
-popd
-

--- a/docker/build-gstreamer/install-dependencies
+++ b/docker/build-gstreamer/install-dependencies
@@ -17,6 +17,7 @@ apt-get install -y --no-install-recommends \
   libunwind-dev \
   libdw-dev \
   libgmp-dev \
+  libgraphene-1.0-dev \
   libgsl-dev \
   libglib2.0-dev \
   flex \


### PR DESCRIPTION
The patches scattered in Nazar's forks were gathered in my GStreamer mono-repo
fork. Libnice is built as a GStreamer subproject now. If we need to bump its
revision it can be done through the corresponding .wrap file in my fork.