### PR TITLE
docker: Bump to GStreamer 1.20 including proper gap event handling fo…

### DIFF
--- a/Dockerfile-dev-downloaded
+++ b/Dockerfile-dev-downloaded
@@ -2,7 +2,7 @@ FROM restreamio/gstreamer:dev-dependencies
 
 ARG GSTREAMER_REPOSITORY=https://gitlab.freedesktop.org/philn/gstreamer.git
 # 1.20-studio branch
-ARG GSTREAMER_CHECKOUT=b404b737f7fa99059a5fbd6fd2eac37fc328e1a1
+ARG GSTREAMER_CHECKOUT=bc9382be3846f9b155580610ff5d2dcbbd9c8849
 
 ARG LIBWPE_VERSION=1.12.0
 ARG WPEBACKEND_FDO_VERSION=1.12.0


### PR DESCRIPTION
…r compositor

This new snapshot includes patches from:
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/708