### PR TITLE
cef: Build gstcefsrc using Restream-hosted CEF build artifacts

### DIFF
--- a/Dockerfile-dev-downloaded
+++ b/Dockerfile-dev-downloaded
@@ -8,6 +8,8 @@ ARG GSTREAMER_CHECKOUT=c7900c9d707d2cec2f275bb5a3e80823b8b148db
 ARG GSTREAMER_CEF_REPOSITORY=https://github.com/centricular/gstcefsrc
 ARG GSTREAMER_CEF_CHECKOUT=444e84264869cf668fe2cb1d4d9b4717f49ae37c
 
+COPY docker/cef-config.sh /.cef-config.sh
+
 COPY docker/sccache.toml /sccache.toml
 
 COPY docker/build-gstreamer/download /download

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -25,23 +25,15 @@ popd
 
 # Build the GStreamer CEF plugin
 pushd gstcefsrc
-GST_CEF_CMAKE_OPTS="-DCMAKE_INSTALL_PREFIX=/usr/cef -GNinja"
-if [[ $DEBUG == 'true' ]]; then
-    if [[ $OPTIMIZATIONS == 'true' ]]; then
-        # RelWithDebInfo doesn't seem supported.
-        GST_CEF_BUILD_TYPE=Release
-    else
-        GST_CEF_BUILD_TYPE=Debug
-    fi
-else
-    GST_CEF_BUILD_TYPE=Release
-fi
-mkdir build
-pushd build
-CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$GST_CEF_BUILD_TYPE $GST_CEF_CMAKE_OPTS ..
-DESTDIR=/compiled-binaries ninja install
-popd
-rm -fr build
+source /.cef-config.sh
+GST_CEF_CMAKE_OPTS="-DCMAKE_INSTALL_PREFIX=/usr/cef -GNinja -DCEF_BUILDS_HOMEPAGE_URL=$CEF_DOWNLOAD_URL -DCEF_VERSION=$CEF_VERSION"
+
+# TODO: Build CEF Debug artifacts as well.
+GST_CEF_BUILD_TYPE=Release
+
+CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=$GST_CEF_BUILD_TYPE $GST_CEF_CMAKE_OPTS -B build -S .
+DESTDIR=/compiled-binaries ninja -C build install
+rm -fr build third_party
 popd
 
 gst-inspect-1.0

--- a/docker/cef-config.sh
+++ b/docker/cef-config.sh
@@ -1,0 +1,4 @@
+
+export CEF_DOWNLOAD_URL=https://restream-archive.s3.eu-west-1.amazonaws.com/cef
+export CEF_VERSION=105.3.11+gd464794+chromium-105.0.5195.37
+


### PR DESCRIPTION
For now only Release builds are provided, Debug builds can be added as well
later on.