### PR TITLE
Add missing dependencies for building gst-docs

### DIFF
--- a/docker/build-gstreamer/install-dependencies
+++ b/docker/build-gstreamer/install-dependencies
@@ -13,6 +13,7 @@ apt-get install -y --no-install-recommends \
   wget \
   python3 \
   python3-pip \
+  python3-dev \
   gcc \
   clang-$CLANG_VERSION \
   cmake \
@@ -130,7 +131,7 @@ apt-get install -y --no-install-recommends \
   glibc-tools \
   libqrencode-dev \
   libjson-glib-dev
-pip3 install meson ninja
+pip3 install meson ninja hotdoc
 
 ARCH=$(dpkg --print-architecture)
 if [[ $ARCH == "amd64" ]]; then


### PR DESCRIPTION
@philn @pldin601 

In order to be able to build the documentation of GStreamer we need 2 additional dependencies.

https://gitlab.freedesktop.org/gstreamer/gst-docs