### PR TITLE
Add libc++ dependency

### DIFF
--- a/docker/build-gstreamer/install-dependencies
+++ b/docker/build-gstreamer/install-dependencies
@@ -21,6 +21,7 @@ apt-get install -y --no-install-recommends \
   libatk-bridge2.0-dev \
   libatspi2.0-dev \
   libcups2-dev \
+  libc++1 \
   libxcomposite-dev \
   libxdamage-dev \
   libunwind-dev \


### PR DESCRIPTION
This is a small change to add `libc++1` to the dependencies to be installed.

This is required by the drivers for Blackmagic Decklink cards. Without this dependency installed any pipelines with Decklink sources or sinks fail to run.