### PR TITLE
Fix: don't add nobody to the render group by default

### DIFF
--- a/Dockerfile-prod-base.in
+++ b/Dockerfile-prod-base.in
@@ -128,11 +128,11 @@ RUN \
 COPY docker/install-arch-specific-dependencies.sh /.install-deps.sh
 RUN /.install-deps.sh
 
-# Add nobody to the render group to allow access to /dev/dri/renderD128
-# It enables access to the Intel GPU through libva for hardware acceleration
+# Add 'render' group to allow access to /dev/dri/renderD128
+# To have access to the Intel GPU through libva for hardware acceleration,
+# running user must be in the 'video' and 'render' groups.
 RUN \
     rm -f /.install-deps.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    groupadd -f -g 110 render && \
-    adduser nobody render
+    groupadd -f -g 110 render


### PR DESCRIPTION
Each individual service will need to add its running user to the video and render groups in order to access Intel GPU hardware acceleration through libva.