### PR TITLE
Fix critical error when an event is dropped in a pad probe

### DIFF
--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -26,6 +26,7 @@ fi
 
 git apply /compile-patch/0001-baseparse-always-update-the-input-pts-if-available-from.patch
 git apply /compile-patch/0001-compositor-add-rounded-corners-property-for-sink-pad.patch
+git apply /compile-patch/0001-pad-Check-data-NULL-ness-when-probes-are-stopped-fixed-in-1.24.8.patch
 
 # This is needed for other plugins to be built properly
 ninja -C build install

--- a/docker/build-gstreamer/patch/0001-pad-Check-data-NULL-ness-when-probes-are-stopped-fixed-in-1.24.8.patch
+++ b/docker/build-gstreamer/patch/0001-pad-Check-data-NULL-ness-when-probes-are-stopped-fixed-in-1.24.8.patch
@@ -1,0 +1,46 @@
+From 78635ce0cd981f4086d254901547ae97caa5e256 Mon Sep 17 00:00:00 2001
+From: Arun Raghavan <arun@asymptotic.io>
+Date: Tue, 10 Sep 2024 16:03:05 -0400
+Subject: [PATCH] pad: Check data NULL-ness when probes are stopped
+
+We were correctly handling this for buffers, but not events and queries.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7506>
+---
+ subprojects/gstreamer/gst/gstpad.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/subprojects/gstreamer/gst/gstpad.c b/subprojects/gstreamer/gst/gstpad.c
+index 276c733c97..355ab9500a 100644
+--- a/subprojects/gstreamer/gst/gstpad.c
++++ b/subprojects/gstreamer/gst/gstpad.c
+@@ -4562,7 +4562,7 @@ probe_handled:
+ probe_stopped:
+   {
+     /* We unref the buffer, except if the probe handled it (CUSTOM_SUCCESS_1) */
+-    if (!handled)
++    if (data && !handled)
+       gst_mini_object_unref (GST_MINI_OBJECT_CAST (data));
+ 
+     switch (ret) {
+@@ -5630,7 +5630,7 @@ inactive:
+ probe_stopped:
+   {
+     GST_OBJECT_FLAG_SET (pad, GST_PAD_FLAG_PENDING_EVENTS);
+-    if (ret != GST_FLOW_CUSTOM_SUCCESS_1)
++    if (event && ret != GST_FLOW_CUSTOM_SUCCESS_1)
+       gst_event_unref (event);
+ 
+     switch (ret) {
+@@ -6039,7 +6039,7 @@ probe_stopped:
+     if (need_unlock)
+       GST_PAD_STREAM_UNLOCK (pad);
+     /* Only unref if unhandled */
+-    if (ret != GST_FLOW_CUSTOM_SUCCESS_1)
++    if (event && ret != GST_FLOW_CUSTOM_SUCCESS_1)
+       gst_event_unref (event);
+ 
+     switch (ret) {
+-- 
+2.43.0
+


### PR DESCRIPTION
This same fix is part of GStreamer 1.24.8