### PR TITLE
Add manual dispatch for the GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Docker Build Workflow
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
     - master


### PR DESCRIPTION
It is useful if the image must be rebuilt to use the new stable version of the Rust compiler