### PR TITLE
Bundle libfakemallinfo.so to work around mallinfo() SIGILL on >2 GiB heaps - COR-1118

### DIFF
--- a/Dockerfile-dev-downloaded.in
+++ b/Dockerfile-dev-downloaded.in
@@ -13,5 +13,6 @@ COPY docker/build-gstreamer/download /download
 
 RUN ["/download"]
 
+COPY docker/build-gstreamer/fake_mallinfo.c /fake_mallinfo.c
 COPY docker/build-gstreamer/compile /compile
 COPY docker/build-gstreamer/patch /compile-patch

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Stable released have 2 tags:
 * regular like `1.18.1` that is a latest build of that upstream release
 * stable reference with one more number after regular `major.minor.patch` that starts with 0 and is incremented if there are multiple builds for the same upstream stable version (like `1.18.1.0`)
 
+## Chromium MemoryInfra SIGILL workaround
+
+glibc's deprecated `mallinfo()` returns `int` fields that overflow once heap addresses exceed 2 GiB. Chromium's MemoryInfra collector still calls it and crashes with SIGILL as soon as a long-running CEF process grows its heap past that threshold. See [chromiumembedded/cef#3963](https://github.com/chromiumembedded/cef/issues/3963).
+
+Image bundles `/usr/lib/libfakemallinfo.so`, a tiny shared library that overrides `mallinfo()` with a stub returning a zeroed `struct mallinfo`. Preload it via `LD_PRELOAD` when starting your binary. In a Dockerfile:
+
+```dockerfile
+ENV LD_PRELOAD=/usr/lib/libfakemallinfo.so
+```
+
+The shim is a no-op for callers that don't use `mallinfo()`, so it's safe to leave preloaded for the whole process tree.
+
 ## Contribution
 Feel free to create issues and send pull requests, they are highly appreciated!
 

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -3,6 +3,14 @@ set -e
 
 source $HOME/.cargo/env
 
+# Build LD_PRELOAD shim that replaces glibc's deprecated mallinfo (which
+# SIGILLs once heap addresses exceed 2 GiB due to int overflow) with one that
+# returns a zeroed struct. Install both into the live filesystem and into
+# /compiled-binaries so it propagates to dev/prod images via COPY --from=0.
+gcc -O2 -Wall -Wextra -fPIC -shared -o /usr/lib/libfakemallinfo.so /fake_mallinfo.c
+mkdir -p /compiled-binaries/usr/lib
+cp /usr/lib/libfakemallinfo.so /compiled-binaries/usr/lib/libfakemallinfo.so
+
 pushd gstreamer
 # TODO: Hack: `-D gupnp=disabled` is for libnice, because libgupnp-igd causes memory leaks
 # msdk=enabled is for gst-plugings-bad to include msdk elements

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -3,10 +3,12 @@ set -e
 
 source $HOME/.cargo/env
 
-# Build LD_PRELOAD shim that replaces glibc's deprecated mallinfo (which
-# SIGILLs once heap addresses exceed 2 GiB due to int overflow) with one that
-# returns a zeroed struct. Install both into the live filesystem and into
-# /compiled-binaries so it propagates to dev/prod images via COPY --from=0.
+# Build LD_PRELOAD shim that replaces glibc's deprecated mallinfo() with a
+# stub returning a zeroed struct. Works around a Chromium bug where
+# MemoryInfra crashes with SIGILL once heap addresses exceed 2 GiB, because
+# mallinfo()'s int fields overflow. Install both into the live filesystem and
+# into /compiled-binaries so it propagates to dev/prod images via COPY --from=0.
+# @see https://github.com/chromiumembedded/cef/issues/3963
 gcc -O2 -Wall -Wextra -fPIC -shared -o /usr/lib/libfakemallinfo.so /fake_mallinfo.c
 mkdir -p /compiled-binaries/usr/lib
 cp /usr/lib/libfakemallinfo.so /compiled-binaries/usr/lib/libfakemallinfo.so

--- a/docker/build-gstreamer/fake_mallinfo.c
+++ b/docker/build-gstreamer/fake_mallinfo.c
@@ -1,3 +1,9 @@
+// LD_PRELOAD shim that replaces glibc's deprecated mallinfo() with a stub
+// returning a zeroed struct. Works around a Chromium bug where MemoryInfra
+// crashes with SIGILL once heap addresses exceed 2 GiB, because mallinfo()'s
+// int fields overflow.
+// @see https://github.com/chromiumembedded/cef/issues/3963
+
 #include <malloc.h>
 
 struct mallinfo mallinfo(void) {

--- a/docker/build-gstreamer/fake_mallinfo.c
+++ b/docker/build-gstreamer/fake_mallinfo.c
@@ -1,0 +1,6 @@
+#include <malloc.h>
+
+struct mallinfo mallinfo(void) {
+    struct mallinfo m = {0};
+    return m;
+}


### PR DESCRIPTION
Bundle libfakemallinfo.so LD_PRELOAD shim in published images                                                                                                                                                                                                                 

glibc's deprecated mallinfo() returns int fields that overflow once heap addresses exceed 2 GiB, causing SIGILL in callers that still use it. Ship a tiny shared library that returns a zeroed struct mallinfo, ready to be loaded via LD_PRELOAD=libfakemallinfo.so.         
                                                            
Build it from docker/build-gstreamer/fake_mallinfo.c at the top of the existing /compile script and install to both /usr/lib/ (live) and /compiled-binaries/usr/lib/. Routing through /compiled-binaries piggybacks on the existing COPY --from=0 steps, so the .so lands in all four published variants (latest-dev-with-source, latest-dev, latest-prod, latest-prod-dbg) with no changes to dev-dependencies or prod-base.