### PR TITLE
Fixes and updates

### DIFF
--- a/Dockerfile-dev-downloaded.in
+++ b/Dockerfile-dev-downloaded.in
@@ -1,6 +1,6 @@
 FROM restreamio/gstreamer:$TARGET_ARCH-dev-dependencies
 
-ARG GSTREAMER_VERSION=1.28.3
+ARG GSTREAMER_VERSION=1.28.4
 
 COPY docker/cef-config.sh /.cef-config.sh
 COPY docker/build-gstreamer/download /download

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -45,9 +45,10 @@ popd
 pushd gstcefsrc
 git apply /compile-patch/cefsrc/0001-cefsrc-download-minimal-package.patch
 git apply /compile-patch/cefsrc/0002-cefsrc-unmultiply-alpha.patch
+git apply /compile-patch/cefsrc/0003-Remove-downloads-SHA1-verification.patch
 
 source /.cef-config.sh
-cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/cef -GNinja -DCEF_VERSION=$CEF_VERSION -DCEF_MINIMAL_PACKAGE=ON
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/cef -GNinja -DCEF_BUILDS_HOMEPAGE_URL=$CEF_BUILDS_HOMEPAGE_URL -DCEF_VERSION=$CEF_VERSION -DCEF_MINIMAL_PACKAGE=ON
 
 DESTDIR=/compiled-binaries ninja -C build install
 rm -fr build third_party

--- a/docker/build-gstreamer/compile
+++ b/docker/build-gstreamer/compile
@@ -33,6 +33,7 @@ fi
 git apply /compile-patch/gstreamer/0001-compositor-add-rounded-corners-property-for-sink-pad.patch
 git apply /compile-patch/gstreamer/0002-compositor-add-box-shadow-property-for-sink-pads.patch
 git apply /compile-patch/gstreamer/0003-Reduce-logs-verbosity-in-webrtcbin-when-a-FEC-decode.patch
+git apply /compile-patch/gstreamer/0004-souphttpsrc-fix-race-conditions-when-looping.patch
 
 # This is needed for other plugins to be built properly
 ninja -C build install

--- a/docker/build-gstreamer/patch/cefsrc/0003-Remove-downloads-SHA1-verification.patch
+++ b/docker/build-gstreamer/patch/cefsrc/0003-Remove-downloads-SHA1-verification.patch
@@ -1,0 +1,34 @@
+From 8f23779a3dc87fbe0b86fa7ddd4c390fa76e536a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Le=20Page?= <llepage@igalia.com>
+Date: Tue, 16 Jun 2026 18:02:02 +0200
+Subject: [PATCH] Remove downloads SHA1 verification
+
+---
+ cmake/DownloadCEF.cmake | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/cmake/DownloadCEF.cmake b/cmake/DownloadCEF.cmake
+index 52f023e..d410103 100644
+--- a/cmake/DownloadCEF.cmake
++++ b/cmake/DownloadCEF.cmake
+@@ -28,17 +28,10 @@ function(DownloadCEF platform version escaped_version download_dir)
+     if(NOT EXISTS "${CEF_DOWNLOAD_PATH}")
+       set(CEF_DOWNLOAD_URL "${CEF_BUILDS_HOMEPAGE_URL}/${CEF_DOWNLOAD_FILENAME}")
+ 
+-      # Download the SHA1 hash for the binary distribution.
+-      message(STATUS "Downloading ${CEF_DOWNLOAD_PATH}.sha1...")
+-      file(DOWNLOAD "${CEF_DOWNLOAD_URL}.sha1" "${CEF_DOWNLOAD_PATH}.sha1")
+-      file(READ "${CEF_DOWNLOAD_PATH}.sha1" CEF_SHA1_UNSTRIPPED)
+-      string(STRIP "${CEF_SHA1_UNSTRIPPED}" CEF_SHA1)
+-
+       # Download the binary distribution and verify the hash.
+       message(STATUS "Downloading ${CEF_DOWNLOAD_PATH}...")
+       file(
+         DOWNLOAD "${CEF_DOWNLOAD_URL}" "${CEF_DOWNLOAD_PATH}"
+-        EXPECTED_HASH SHA1=${CEF_SHA1}
+         SHOW_PROGRESS
+         )
+     endif()
+-- 
+2.43.0
+

--- a/docker/build-gstreamer/patch/gstreamer/0004-souphttpsrc-fix-race-conditions-when-looping.patch
+++ b/docker/build-gstreamer/patch/gstreamer/0004-souphttpsrc-fix-race-conditions-when-looping.patch
@@ -1,0 +1,162 @@
+From a916232763016e6c0d68f9073822b8bee1094b72 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lo=C3=AFc=20Le=20Page?= <llepage@igalia.com>
+Date: Tue, 16 Jun 2026 16:34:31 +0200
+Subject: [PATCH] souphttpsrc: fix race conditions when looping
+
+There are 2 race conditions happenning when seeking-flush to 0 after
+receiving the EOS with `souphttpsrc`:
+- When the request is cancelled at the moment of the flush, the
+  `SoupMessage` is not reset, which may lead to not correctly start the
+  next request and so we may be waiting forever on the `src->session_cond`.
+  This patch systematically clears the dropped `SoupMessage` when the
+  request is cancelled and the element is flushing.
+- When the seek-flush happens, the `src->cancellable` may be reset while a
+  request is still processing. As the `g_cancellable_reset()` documentation
+  states: "If cancellable is currently in use by any cancellable operation
+  then the behavior of this function is undefined". To avoid this
+  situation, this patch uses specific cancellables for each individual
+  Send/Read request. The top-level `src->cancellable` is only used to manage
+  the cancellation state and to trigger the request specific
+  dropped-after-use cancellable.
+---
+ .../ext/soup/gstsouphttpsrc.c                 | 28 +++++++++++++++++--
+ 1 file changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/subprojects/gst-plugins-good/ext/soup/gstsouphttpsrc.c b/subprojects/gst-plugins-good/ext/soup/gstsouphttpsrc.c
+index 0c1db5bea3..422f9a3287 100644
+--- a/subprojects/gst-plugins-good/ext/soup/gstsouphttpsrc.c
++++ b/subprojects/gst-plugins-good/ext/soup/gstsouphttpsrc.c
+@@ -1960,6 +1960,7 @@ struct GstSoupSendSrc
+ {
+   GstSoupHTTPSrc *src;
+   GError *error;
++  GCancellable *soup_cancellable;
+ };
+ 
+ static void
+@@ -1976,6 +1977,7 @@ _session_send_cb (GObject * source, GAsyncResult * res, gpointer user_data)
+ 
+   if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+     src->headers_ret = GST_FLOW_FLUSHING;
++    g_clear_object (&src->msg);
+   } else {
+     src->headers_ret = gst_soup_http_src_got_headers (src, src->msg);
+   }
+@@ -1995,8 +1997,8 @@ _session_send_idle_cb (gpointer user_data)
+   struct GstSoupSendSrc *msrc = user_data;
+   GstSoupHTTPSrc *src = msrc->src;
+ 
+-  _soup_session_send_async (src->session->session, src->msg, src->cancellable,
+-      _session_send_cb, msrc);
++  _soup_session_send_async (src->session->session, src->msg,
++      msrc->soup_cancellable, _session_send_cb, msrc);
+ 
+   return FALSE;
+ }
+@@ -2008,12 +2010,16 @@ gst_soup_http_src_send_message (GstSoupHTTPSrc * src)
+   GstFlowReturn ret;
+   GSource *source;
+   struct GstSoupSendSrc msrc;
++  gulong cancel_id;
+ 
+   g_return_val_if_fail (src->msg != NULL, GST_FLOW_ERROR);
+   g_assert (src->input_stream == NULL);
+ 
+   msrc.src = src;
+   msrc.error = NULL;
++  msrc.soup_cancellable = g_cancellable_new ();
++  cancel_id = g_cancellable_connect (src->cancellable,
++      G_CALLBACK (g_cancellable_cancel), msrc.soup_cancellable, NULL);
+ 
+   source = g_idle_source_new ();
+ 
+@@ -2026,6 +2032,9 @@ gst_soup_http_src_send_message (GstSoupHTTPSrc * src)
+   while (!src->input_stream && !msrc.error)
+     g_cond_wait (&src->session_cond, &src->session_mutex);
+ 
++  g_cancellable_disconnect (src->cancellable, cancel_id);
++  g_object_unref (msrc.soup_cancellable);
++
+   ret = src->headers_ret;
+ 
+   if (ret != GST_FLOW_OK) {
+@@ -2117,6 +2126,7 @@ gst_soup_http_src_do_request (GstSoupHTTPSrc * src, const gchar * method)
+ 
+   if (g_cancellable_is_cancelled (src->cancellable)) {
+     GST_INFO_OBJECT (src, "interrupted");
++    g_clear_object (&src->msg);
+     return GST_FLOW_FLUSHING;
+   }
+ 
+@@ -2218,6 +2228,7 @@ struct GstSoupReadResult
+   void *buffer;
+   gsize bufsize;
+   gssize nbytes;
++  GCancellable *soup_cancellable;
+ };
+ 
+ static void
+@@ -2240,7 +2251,7 @@ _session_read_idle_cb (gpointer user_data)
+   struct GstSoupReadResult *res = user_data;
+ 
+   g_input_stream_read_async (res->src->input_stream, res->buffer,
+-      res->bufsize, G_PRIORITY_DEFAULT, res->src->cancellable,
++      res->bufsize, G_PRIORITY_DEFAULT, res->soup_cancellable,
+       _session_read_cb, res);
+ 
+   return FALSE;
+@@ -2254,6 +2265,7 @@ gst_soup_http_src_read_buffer (GstSoupHTTPSrc * src, GstBuffer ** outbuf)
+   GstBaseSrc *bsrc;
+   GstFlowReturn ret;
+   GSource *source;
++  gulong cancel_id;
+ 
+   bsrc = GST_BASE_SRC_CAST (src);
+ 
+@@ -2273,6 +2285,9 @@ gst_soup_http_src_read_buffer (GstSoupHTTPSrc * src, GstBuffer ** outbuf)
+   res.bufsize = mapinfo.size;
+   res.error = NULL;
+   res.nbytes = -1;
++  res.soup_cancellable = g_cancellable_new ();
++  cancel_id = g_cancellable_connect (src->cancellable,
++      G_CALLBACK (g_cancellable_cancel), res.soup_cancellable, NULL);
+ 
+   source = g_idle_source_new ();
+ 
+@@ -2296,12 +2311,15 @@ gst_soup_http_src_read_buffer (GstSoupHTTPSrc * src, GstBuffer ** outbuf)
+     GstFlowReturn ret = GST_FLOW_CUSTOM_ERROR;
+     if (g_error_matches (res.error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+       ret = GST_FLOW_FLUSHING;
++      g_clear_object (&src->msg);
+     } else {
+       GST_ERROR_OBJECT (src, "Got error from libsoup: %s", res.error->message);
+     }
+     g_error_free (res.error);
+     gst_buffer_unmap (*outbuf, &mapinfo);
+     gst_buffer_unref (*outbuf);
++    g_cancellable_disconnect (src->cancellable, cancel_id);
++    g_object_unref (res.soup_cancellable);
+     return ret;
+   }
+ 
+@@ -2372,6 +2390,9 @@ gst_soup_http_src_read_buffer (GstSoupHTTPSrc * src, GstBuffer ** outbuf)
+ 
+   g_clear_error (&res.error);
+ 
++  g_cancellable_disconnect (src->cancellable, cancel_id);
++  g_object_unref (res.soup_cancellable);
++
+   return ret;
+ }
+ 
+@@ -2383,6 +2404,7 @@ _session_stream_clear_cb (gpointer user_data)
+   g_mutex_lock (&src->session_mutex);
+ 
+   g_clear_object (&src->input_stream);
++  g_clear_object (&src->msg);
+ 
+   g_cond_signal (&src->session_cond);
+   g_mutex_unlock (&src->session_mutex);
+-- 
+2.43.0
+

--- a/docker/cef-config.sh
+++ b/docker/cef-config.sh
@@ -1,3 +1,7 @@
+# `cefsrc` element source code
 export CEF_REPOSITORY=https://github.com/centricular/gstcefsrc
 export CEF_CHECKOUT=b63340852fc93b0ab67b07200e1ff44f59ba6769
-export CEF_VERSION=147.0.14+g76d2442+chromium-147.0.7727.138
+
+# CEF pre-built binaries
+export CEF_BUILDS_HOMEPAGE_URL=https://github.com/restreamio/cef-builder/releases/download/2026-06-15T10-54-00Z
+export CEF_VERSION=148.0.10+g7ee53f5+chromium-148.0.7778.218


### PR DESCRIPTION
- Add GStreamer patch to fix race conditions in the `souphttpsrc` element.
- Upgrade GStreamer to 1.28.4.
- Use custom-built CEF pre-built binaries from Restream.io `cef-builder` repo.