### PR TITLE
fix: make rtmp2 cancel_all_commands re-entrancy safe

### DIFF
--- a/docker/build-gstreamer/patch/gstreamer/0004-rtmp2-rtmpclient-Close-the-connection-when-the-conne.patch
+++ b/docker/build-gstreamer/patch/gstreamer/0004-rtmp2-rtmpclient-Close-the-connection-when-the-conne.patch
@@ -1,8 +1,8 @@
-From 2494f52e5863405370d26d5958aed8ddf08c6145 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mykhailo Chelnokov <mchelnokov@gmail.com>
-Date: Mon, 17 Aug 2026 12:53:01 +0300
-Subject: [PATCH 1/3] rtmp2/rtmpclient: Close the connection when the connect
- task fails
+Date: Fri, 4 Sep 2026 10:54:39 +0300
+Subject: [PATCH 1/3] rtmp2/rtmpclient: Close the connection when the connect task
+ fails
 
 A GstRtmpConnection's input GSource holds a strong reference back to
 the connection, and the connection references the GMainContext the
@@ -28,9 +28,14 @@ https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1425
 and fixed by 1f7515100caf06fb31d84a40be49dcefd176fce3 ("rtmp2/connection:
 pass the parent cancellable down to the connection"); the rejection
 flavour described in the same report was not covered by that fix.
+
+Closing from a command callback re-enters cancel_all_commands () while
+it is still walking its lists; detach the lists first so a nested call
+finds nothing and no callback runs twice.
 ---
- .../gst-plugins-bad/gst/rtmp2/rtmp/rtmpclient.c       | 11 +++++++++--
- 1 file changed, 9 insertions(+), 2 deletions(-)
+ .../gst-plugins-bad/gst/rtmp2/rtmp/rtmpclient.c     | 11 +++++++++--
+ .../gst-plugins-bad/gst/rtmp2/rtmp/rtmpconnection.c | 13 +++++++------
+ 2 files changed, 16 insertions(+), 8 deletions(-)
 
 diff --git a/subprojects/gst-plugins-bad/gst/rtmp2/rtmp/rtmpclient.c b/subprojects/gst-plugins-bad/gst/rtmp2/rtmp/rtmpclient.c
 index d61e407..556d25e 100644
@@ -61,6 +66,43 @@ index d61e407..556d25e 100644
        gst_rtmp_connection_close_and_unref);
    g_object_unref (task);
  }
+diff --git a/subprojects/gst-plugins-bad/gst/rtmp2/rtmp/rtmpconnection.c b/subprojects/gst-plugins-bad/gst/rtmp2/rtmp/rtmpconnection.c
+index a93fd12..ac7aeab 100644
+--- a/subprojects/gst-plugins-bad/gst/rtmp2/rtmp/rtmpconnection.c
++++ b/subprojects/gst-plugins-bad/gst/rtmp2/rtmp/rtmpconnection.c
+@@ -375,25 +375,26 @@ gst_rtmp_connection_new (GSocketConnection * connection,
+ static void
+ cancel_all_commands (GstRtmpConnection * self, const gchar * reason)
+ {
++  /* Callbacks may close the connection and re-enter; detach the lists first */
++  GList *transactions = g_steal_pointer (&self->transactions);
++  GList *expected_commands = g_steal_pointer (&self->expected_commands);
+   GList *l;
+ 
+-  for (l = self->transactions; l; l = g_list_next (l)) {
++  for (l = transactions; l; l = g_list_next (l)) {
+     Transaction *cc = l->data;
+     GST_LOG_OBJECT (self, "calling transaction callback %s",
+         GST_DEBUG_FUNCPTR_NAME (cc->func));
+     cc->func (reason, NULL, cc->user_data);
+   }
+-  g_list_free_full (self->transactions, transaction_free);
+-  self->transactions = NULL;
++  g_list_free_full (transactions, transaction_free);
+ 
+-  for (l = self->expected_commands; l; l = g_list_next (l)) {
++  for (l = expected_commands; l; l = g_list_next (l)) {
+     ExpectedCommand *cc = l->data;
+     GST_LOG_OBJECT (self, "calling expected command callback %s",
+         GST_DEBUG_FUNCPTR_NAME (cc->func));
+     cc->func (reason, NULL, cc->user_data);
+   }
+-  g_list_free_full (self->expected_commands, expected_command_free);
+-  self->expected_commands = NULL;
++  g_list_free_full (expected_commands, expected_command_free);
+ }
+ 
+ void
 -- 
 2.55.0
 


### PR DESCRIPTION
The rtmp2 patches close the connection from inside a command callback, which re-enters cancel_all_commands while it walks its lists: the callback runs twice and double-unrefs its GTask (SIGSEGV in g_object_unref on the rtmp2src task thread). Detach the lists before walking them.